### PR TITLE
Update Prismatic's Plumbing dependency to 0.4.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [com.stuartsierra/component "0.2.1"]
-                 [prismatic/plumbing "0.2.2"]]
+                 [prismatic/plumbing "0.4.3"]]
   :profiles {:dev {:plugins [[lein-midje "3.1.3-RC2"]]
                    :dependencies [[org.clojure/tools.namespace "0.2.4"]
                                   [midje "1.6-beta1"]]


### PR DESCRIPTION
I'm using system-graph to compile a large graph of components and in this scenario it makes sense to have namespaced configs for otherwise conflicting configs. An example where this happens when you have a database component and server component. Both need a `:port` config. You can prefix it with `:database-` and `:server-` respectively, but it feels more natural to use a namespace here.

This namespacing is supported since Plumbing's `0.3.7` version and System-graph is currently relying on `0.2.0` so hence the update.

Thanks for this library btw, it saves a lot of hassle of writing validations and managing dependencies when using component!
